### PR TITLE
Update link since previous one is 404 now.

### DIFF
--- a/examples/09-raycaster.html
+++ b/examples/09-raycaster.html
@@ -66,7 +66,7 @@
             side: THREE.DoubleSide
         });
 
-		import { GUI } from 'https://threejs.org/examples/jsm/libs/dat.gui.module.js';
+		import { GUI } from 'https://threejs.org/examples/jsm/libs/lil-gui.module.min.js';
 		import Stats from 'https://threejs.org/examples/jsm/libs/stats.module.js';
 
 		let stats, gui;


### PR DESCRIPTION
I was trying to run an example right now and in the raycaster example the link to https://threejs.org/examples/jsm/libs/dat.gui.module.js lead to a 404.

https://threejs.org/examples/jsm/libs/lil-gui.module.min.js fixed the issue and demo seemed to work fine.