### PR TITLE
BuildingShadows compatible with Mapbox v2

### DIFF
--- a/src/objects/effects/BuildingShadows.js
+++ b/src/objects/effects/BuildingShadows.js
@@ -77,7 +77,7 @@ class BuildingShadows {
 			const bucket = tile.getBucket(buildingsLayer);
 			if (!bucket) continue;
 			const [heightBuffer, baseBuffer] = bucket.programConfigurations.programConfigurations[this.buildingsLayerId]._buffers;
-			gl.uniformMatrix4fv(this.uMatrix, false, coord.posMatrix);
+			gl.uniformMatrix4fv(this.uMatrix, false, (coord.posMatrix || coord.projMatrix));
 			gl.uniform1f(this.uHeightFactor, Math.pow(2, coord.overscaledZ) / tile.tileSize / 8);
 			for (const segment of bucket.segments.get()) {
 				const numPrevAttrib = context.currentNumAttributes || 0;

--- a/src/objects/effects/BuildingShadows.js
+++ b/src/objects/effects/BuildingShadows.js
@@ -19,27 +19,9 @@ class BuildingShadows {
 			console.warn(`Can't find layer ${this.buildingsLayerId}'s source.`);
 		}
 
-		const vertexSource = `
-			uniform mat4 u_matrix;
-			uniform float u_height_factor;
-			uniform float u_altitude;
-			uniform float u_azimuth;
-			attribute vec2 a_pos;
-			attribute vec4 a_normal_ed;
-			attribute lowp vec2 a_base;
-			attribute lowp vec2 a_height;
-			void main() {
-				float base = max(0.0, a_base.x);
-				float height = max(0.0, a_height.x);
-				float t = mod(a_normal_ed.x, 2.0);
-				vec4 pos = vec4(a_pos, t > 0.0 ? height : base, 1);
-				float len = pos.z * u_height_factor / tan(u_altitude);
-				pos.x += cos(u_azimuth) * len;
-				pos.y += sin(u_azimuth) * len;
-				pos.z = 0.0;
-				gl_Position = u_matrix * pos;
-			}
-			`;
+		// vertex shader of fill-extrusion layer is different in mapbox v1 and v2.
+		// https://github.com/mapbox/mapbox-gl-js/commit/cef95aa0241e748b396236f1269fbb8270f31565
+		const vertexSource = this._getVertexSource();
 		const fragmentSource = `
 			void main() {
 				gl_FragColor = vec4(0.0, 0.0, 0.0, 0.7);
@@ -60,8 +42,14 @@ class BuildingShadows {
 		this.uHeightFactor = gl.getUniformLocation(this.program, "u_height_factor");
 		this.uAltitude = gl.getUniformLocation(this.program, "u_altitude");
 		this.uAzimuth = gl.getUniformLocation(this.program, "u_azimuth");
-		this.aPos = gl.getAttribLocation(this.program, "a_pos");
-		this.aNormal = gl.getAttribLocation(this.program, "a_normal_ed");
+
+		if (this.tb.mapboxVersion >= 2.0) {
+			this.aPosNormal = gl.getAttribLocation(this.program, "a_pos_normal_ed");
+		} else {
+			this.aPos = gl.getAttribLocation(this.program, "a_pos");
+			this.aNormal = gl.getAttribLocation(this.program, "a_normal_ed");
+		}
+
 		this.aBase = gl.getAttribLocation(this.program, "a_base");
 		this.aHeight = gl.getAttribLocation(this.program, "a_height");
 	}
@@ -96,13 +84,19 @@ class BuildingShadows {
 				const numNextAttrib = 2;
 				for (let i = numNextAttrib; i < numPrevAttrib; i++) gl.disableVertexAttribArray(i);
 				const vertexOffset = segment.vertexOffset || 0;
-				gl.enableVertexAttribArray(this.aPos);
 				gl.enableVertexAttribArray(this.aNormal);
 				gl.enableVertexAttribArray(this.aHeight);
 				gl.enableVertexAttribArray(this.aBase);
 				bucket.layoutVertexBuffer.bind();
-				gl.vertexAttribPointer(this.aPos, 2, gl.SHORT, false, 12, 12 * vertexOffset);
-				gl.vertexAttribPointer(this.aNormal, 4, gl.SHORT, false, 12, 4 + 12 * vertexOffset);
+				if (this.tb.mapboxVersion >= 2.0) {
+					gl.enableVertexAttribArray(this.aPosNormal);
+					gl.vertexAttribPointer(this.aPosNormal, 4, gl.SHORT, false, 8, 8 * vertexOffset);
+				} else {
+					gl.enableVertexAttribArray(this.aPos);
+					gl.vertexAttribPointer(this.aPos, 2, gl.SHORT, false, 12, 12 * vertexOffset);
+					gl.vertexAttribPointer(this.aNormal, 4, gl.SHORT, false, 12, 4 + 12 * vertexOffset);
+				}
+
 				heightBuffer.bind();
 				gl.vertexAttribPointer(this.aHeight, 1, gl.FLOAT, false, 4, 4 * vertexOffset);
 				baseBuffer.bind();
@@ -111,6 +105,57 @@ class BuildingShadows {
 				context.currentNumAttributes = numNextAttrib;
 				gl.drawElements(gl.TRIANGLES, segment.primitiveLength * 3, gl.UNSIGNED_SHORT, segment.primitiveOffset * 3 * 2);
 			}
+		}
+	}
+
+	_getVertexSource() {
+		if (this.tb.mapboxVersion >= 2.0) {
+			return `
+				uniform mat4 u_matrix;
+				uniform float u_height_factor;
+				uniform float u_altitude;
+				uniform float u_azimuth;
+				attribute vec4 a_pos_normal_ed;
+				attribute lowp vec2 a_base;
+				attribute lowp vec2 a_height;
+				void main() {
+					float base = max(0.0, a_base.x);
+					float height = max(0.0, a_height.x);
+
+					vec3 pos_nx = floor(a_pos_normal_ed.xyz * 0.5);
+					mediump vec3 top_up_ny = a_pos_normal_ed.xyz - 2.0 * pos_nx;
+					float t = top_up_ny.x;
+					vec4 pos = vec4(pos_nx.xy, t > 0.0 ? height : base, 1);
+
+					float len = pos.z * u_height_factor / tan(u_altitude);
+					pos.x += cos(u_azimuth) * len;
+					pos.y += sin(u_azimuth) * len;
+					pos.z = 0.0;
+					gl_Position = u_matrix * pos;
+				}
+			`;
+		} else {
+			return `
+				uniform mat4 u_matrix;
+				uniform float u_height_factor;
+				uniform float u_altitude;
+				uniform float u_azimuth;
+				attribute vec2 a_pos;
+				attribute vec4 a_normal_ed;
+				attribute lowp vec2 a_base;
+				attribute lowp vec2 a_height;
+				void main() {
+					float base = max(0.0, a_base.x);
+					float height = max(0.0, a_height.x);
+					float t = mod(a_normal_ed.x, 2.0);
+					vec4 pos = vec4(a_pos, t > 0.0 ? height : base, 1);
+					float len = pos.z * u_height_factor / tan(u_altitude);
+					pos.x += cos(u_azimuth) * len;
+					pos.y += sin(u_azimuth) * len;
+					pos.z = 0.0;
+					gl_Position = u_matrix * pos;
+				}
+			`;
 		}
 	}
 }


### PR DESCRIPTION
Vertex shader of fill-extrusion layer is changed in mapbox v2, so vertex shader of building shadow should be modified samely. 
Tested on Mapbox `v1.11.0`, `v2.0.0`, `v2.2.0`, `v2.3.0`.
<img width="1627" alt="image" src="https://user-images.githubusercontent.com/10242480/188659938-72ad3797-3958-4096-816c-0c0696a39322.png">
