### PR TITLE
Add with credentials to loadObj options

### DIFF
--- a/src/objects/loadObj.js
+++ b/src/objects/loadObj.js
@@ -41,6 +41,7 @@ function loadObj(options, cb, promise) {
 			break;
 	}
 
+	materialLoader.withCredentials = options.withCredentials;
 	materialLoader.load(options.mtl, loadObject, () => (null), error => {
 		console.warn("No material file found " + error.stack);
 	});
@@ -52,6 +53,7 @@ function loadObj(options, cb, promise) {
 			loader.setMaterials(materials);
 		}
 
+		loader.withCredentials = options.withCredentials;
 		loader.load(options.obj, obj => {
 
 			//[jscastro] MTL/GLTF/FBX models have a different structure

--- a/src/objects/objects.js
+++ b/src/objects/objects.js
@@ -1072,7 +1072,8 @@ Objects.prototype = {
 			bbox: true,
 			tooltip: true,
 			raycasted: true,
-			clone: true
+			clone: true,
+			withCredentials: false
 		},
 
 		Object3D: {


### PR DESCRIPTION
Sometimes requests credentials are required to be successful, in my case it's requests to the AWS CDN. 
So I added `withCredentials` to loadObj options, so requests will have credentials.

options example:
```
  const windTurbineOptions = {
    obj: awsCdnUrl,
    type: 'gltf',
    scale: 1,
    units: 'meters',
    anchor: 'center',
    withCredentials: true,
  };
  tb.loadObj(windTurbineOptions, (model) => {
    const { longitude, latitude } = location
    model.setCoords([longitude, latitude, groundAlt]);
    tb.add(model);
  });
```

