### PR TITLE
fix loading models without materials

### DIFF
--- a/src/objects/loadObj.js
+++ b/src/objects/loadObj.js
@@ -41,10 +41,16 @@ function loadObj(options, cb, promise) {
 			break;
 	}
 
-	materialLoader.withCredentials = options.withCredentials;
-	materialLoader.load(options.mtl, loadObject, () => (null), error => {
-		console.warn("No material file found " + error.stack);
-	});
+	if (options.mtl){
+		materialLoader.withCredentials = options.withCredentials;
+		materialLoader.load(options.mtl, loadObject, () => (null), error => {
+			console.warn("No material file found " + error.stack);
+		});
+	}
+	else{
+		loadObject(undefined)
+	}
+	
 
 	function loadObject(materials) {
 


### PR DESCRIPTION
Buenas Jesus! Subo un fix de un problema que me he encontrado:

When using onAdd, if options.mtl is not specified MTLLoader.js fails and the model is not loaded.
I encountered this error using .glb file.
when url is not passed, loader.load call is made with url = current navigation path.
When testing in local this value was localhost:3000, which worked well (returned 304 and then object is loaded)
When uploading to production, url value was https://dev.immersia.eu/emplazamiento/45, (note that this is the current frontend path where map is rendered). I have frontend in aws cloudfront, the response is 404 and the model is not loaded

How to reproduce: pass https://dev.immersia.eu/emplazamiento/45, for example, as options.mtl for tb.loadObj function.

My fix:
If material is specified, try to load the material, if not, just render the object without the material.
I tried it and it works.


Temporal fix, just use a url that doesn't return an error value for mtl field (any page with allow any cors origin?), for example:

const options = {
            obj: modelUrl,
            type: modelType,
            units: "meters",
            scale: layerScale,
            anchor: "bottom",
            rotation: { x: 90, y: 0, z: 0 },
            mtl: "https://jsonplaceholder.typicode.com/",
          };


![image](https://github.com/user-attachments/assets/cb6fb63d-0891-4b37-b9f3-3ee1ad980d3a)
